### PR TITLE
Fix asset compilation

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,11 @@ add an initializer (no generator so far):
     # explicit gem dependencies and keep this gem lean. If you prefer to use
     # other libs, enter them here.
     config.bootstrap_css_url = '//some.cdn.com/...'
+    config.bootstrap_css_integrity = '...'
     config.bootstrap_js_url = '//some.cdn.com/...'
+    config.bootstrap_js_integrity = '...'
+    config.jquery_url = '//some.cdn.com/...'
+    config.jquery_integrity = '...'
   end
 </pre>
 

--- a/app/assets/config/i18n_o7r_manifest.js
+++ b/app/assets/config/i18n_o7r_manifest.js
@@ -1,0 +1,3 @@
+//= link_directory ../stylesheets/i18n_o7r .css
+//= link_directory ../javascripts/i18n_o7r .js
+//= link_directory ../images/i18n_o7r

--- a/app/assets/javascripts/i18n_o7r/application.js
+++ b/app/assets/javascripts/i18n_o7r/application.js
@@ -10,8 +10,7 @@
 // Read Sprockets README (https://github.com/sstephenson/sprockets#sprockets-directives) for details
 // about supported directives.
 //
-//= require jquery
-//= require jquery_ujs
+//= require rails-ujs
 //= require ./jquery.autosize.min
 //= require ./easyTree
 //= require ./i18n_o7r

--- a/app/views/layouts/i18n_o7r/application.html.slim
+++ b/app/views/layouts/i18n_o7r/application.html.slim
@@ -5,10 +5,11 @@ html
     meta http-equiv="X-UA-Compatible" content="IE=edge"
     meta name="viewport" content="width=device-width, initial-scale=1"
     title I18nO7r – Internationalization Organizer
-    = stylesheet_link_tag I18nO7r.bootstrap_css_url, media: "all"
+    = stylesheet_link_tag I18nO7r.bootstrap_css_url, integrity: I18nO7r.bootstrap_css_integrity, crossorigin: "anonymous", media: "all"
     = stylesheet_link_tag 'i18n_o7r/application', media: "all"
+    = javascript_include_tag I18nO7r.jquery_url, integrity: I18nO7r.jquery_integrity, crossorigin: "anonymous"
     = javascript_include_tag 'i18n_o7r/application'
-    = javascript_include_tag I18nO7r.bootstrap_js_url
+    = javascript_include_tag I18nO7r.bootstrap_js_url, integrity: I18nO7r.bootstrap_js_integrity, crossorigin: "anonymous"
     = csrf_meta_tags
 body
   nav class="navbar navbar-inverse navbar-fixed-top"

--- a/i18n_o7r.gemspec
+++ b/i18n_o7r.gemspec
@@ -14,6 +14,10 @@ Gem::Specification.new do |s|
   s.description = "I18nO7r is supposed to make life easier by organizing the i18n ymls in a very strict manner, allowing to edit the translations interactively and automatically detect missing locales as-you-use."
   s.license     = "MIT"
 
+  s.add_dependency "sprockets-rails"
+  s.add_dependency "sass-rails"
+  s.add_dependency "slim-rails"
+
   s.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.rdoc"]
   s.test_files = Dir["test/**/*"]
 end

--- a/lib/i18n_o7r.rb
+++ b/lib/i18n_o7r.rb
@@ -1,7 +1,14 @@
 require 'yaml/store'
 
-BOOTSTRAP_CSS_CDN_URL = '//maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css'
-BOOTSTRAP_JS_CDN_URL  = '//maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js'
+# https://getbootstrap.com/docs/3.4/getting-started/#download-cdn
+BOOTSTRAP_CSS_CDN_URL       = "https://cdn.jsdelivr.net/npm/bootstrap@3.4.1/dist/css/bootstrap.min.css"
+BOOTSTRAP_CSS_CDN_INTEGRITY = "sha384-HSMxcRTRxnN+Bdg0JdbxYKrThecOKuH5zCYotlSAcp1+c8xmyTe9GYg1l9a69psu"
+BOOTSTRAP_JS_CDN_URL        = "https://cdn.jsdelivr.net/npm/bootstrap@3.4.1/dist/js/bootstrap.min.js"
+BOOTSTRAP_JS_CDN_INTEGRITY  = "sha384-aJ21OjlMXNL5UyIl/XNwTMqvzeRMZH2w8c5cRVpzpU8Y5bApTppSuUkhZXN0VxHd"
+
+# https://releases.jquery.com/
+JQUERY_CDN_URL              = "https://code.jquery.com/jquery-3.6.0.slim.min.js"
+JQUERY_CDN_INTEGRITY        = "sha256-u7e5khyithlIdTpu22PHhENmPcRdFiHRjhAuHcs05RI="
 
 module I18nO7r
   mattr_accessor :dump_location
@@ -12,7 +19,11 @@ module I18nO7r
   mattr_accessor :languages
   mattr_accessor :configured
   mattr_accessor :bootstrap_css_url
+  mattr_accessor :bootstrap_css_integrity
   mattr_accessor :bootstrap_js_url
+  mattr_accessor :bootstrap_js_integrity
+  mattr_accessor :jquery_url
+  mattr_accessor :jquery_integrity
   mattr_accessor :save_missing_translations_in_envs
   mattr_accessor :missing_translations_filename
   mattr_accessor :ignore_missing_pattern
@@ -23,7 +34,11 @@ module I18nO7r
   @@languages                 = I18n.available_locales
   @@primary_language          = I18n.locale
   @@bootstrap_js_url          = BOOTSTRAP_JS_CDN_URL
+  @@bootstrap_js_integrity    = BOOTSTRAP_JS_CDN_INTEGRITY
   @@bootstrap_css_url         = BOOTSTRAP_CSS_CDN_URL
+  @@bootstrap_css_integrity   = BOOTSTRAP_CSS_CDN_INTEGRITY
+  @@jquery_url                = JQUERY_CDN_URL
+  @@jquery_integrity          = JQUERY_CDN_INTEGRITY
   @@save_missing_translations_in_envs = %w{development}
   @@missing_translations_filename = nil
   @@keep_backup               = false

--- a/lib/i18n_o7r/engine.rb
+++ b/lib/i18n_o7r/engine.rb
@@ -1,3 +1,6 @@
 class I18nO7r::Engine < ::Rails::Engine
   isolate_namespace I18nO7r
+  initializer "i18n_o7r.assets.precompile" do |app|
+    app.config.assets.precompile += %w[i18n_o7r_manifest]
+  end
 end


### PR DESCRIPTION
not rails apps use sprockets or sassc, so we should list them as dependencies

by including jquery from a cdn and using rails-ujs instead of jquery-ujs we can drop the jquery-rails dependency

by adding a manifest and adding it to the config.assets.precompile assets of this gem are included in the asset pipeline and will not raise an error due to the assets not being configured for precompilation