### PR TITLE
do not create empty translation yml

### DIFF
--- a/lib/i18n/find_missing_translations.rb
+++ b/lib/i18n/find_missing_translations.rb
@@ -23,9 +23,10 @@ if I18nO7r.save_missing_translations_in_envs.member?(Rails.env.to_s)
       end
       # The key wasn't found and we're prepared to write it away
       return nil if ignored
-      if I18nO7r.missing_translations_filename
+      # only begin transaction if we have keys to write,
+      # otherwise we would create an empty file that is not accepted by I18n
+      if I18nO7r.missing_translations_filename && (keys = I18n.normalize_keys(locale, key, scope, options[:separator])).any?
         mt_store = YAML::Store.new(I18nO7r.missing_translations_filename)
-        keys = I18n.normalize_keys(locale, key, scope, options[:separator])
         mt_store.transaction do
           keys.each.with_index.inject(mt_store) do |a, (e, i)|
             # puts ">> #{a} -> #{e}, #{i}"

--- a/lib/tasks/i18n_o7r_tasks.rake
+++ b/lib/tasks/i18n_o7r_tasks.rake
@@ -26,6 +26,8 @@ namespace :i18n_o7r do
         mt_store.delete(root) if updated_hash.empty?
       end
     end # store transaction
+    # empty translation files are not accepted by I18n
+    File.delete(I18nO7r.missing_translations_filename) if File.empty?(I18nO7r.missing_translations_filename)
     @store = I18nO7r::Store.new
     @store.unify!
     @store.dump!


### PR DESCRIPTION
I18n throws an error if it tries to load file that does not return a hash